### PR TITLE
Correção - nomes com D ficam com letra minúscula

### DIFF
--- a/AngularJS_9_Criando_Filtros/js/filters/nameFilter.js
+++ b/AngularJS_9_Criando_Filtros/js/filters/nameFilter.js
@@ -2,7 +2,9 @@ angular.module("listaTelefonica").filter("name", function () {
 	return function (input) {
 		var listaDeNomes = input.split(" ");
 		var listaDeNomesFormatada = listaDeNomes.map(function (nome) {
-			if (/(da|de)/.test(nome)) return nome;
+			if(nome.length <= 3) {
+            			if(/(da|de|do|das|dos)/.test(nome)) return nome;
+         		}
 			return nome.charAt(0).toUpperCase() + nome.substring(1).toLowerCase();
 		});
 		return listaDeNomesFormatada.join(" ");


### PR DESCRIPTION
Na versão original nomes com D ficam com letra minúscula, exemplo Daniel e Denise.
Versão original também não tem lowercase nos casos de sobrenomes ligados por do, das e dos (exemplo - dos Santos, das Rosas).