### PR TITLE
Ellipsis

### DIFF
--- a/AngularJS_9_Criando_Filtros/js/filters/ellipsisFilter.js
+++ b/AngularJS_9_Criando_Filtros/js/filters/ellipsisFilter.js
@@ -1,7 +1,8 @@
 angular.module("listaTelefonica").filter("ellipsis", function () {
 	return function (input, size) {
+		size = size || 2;
 		if (input.length <= size) return input;
-		var output = input.substring(0,(size || 2)) + "...";
+		var output = input.substring(0,size) + "...";
 		return output;
 	};
 });


### PR DESCRIPTION
Atribuindo o size default antes de verificar o input.length para evitar que strings com menos de X caracteres (2 no caso) mostre os "..." ao final da palavra.